### PR TITLE
Configure the Stryker config file location

### DIFF
--- a/packages/core/src/server/methods/instrument-method.ts
+++ b/packages/core/src/server/methods/instrument-method.ts
@@ -1,5 +1,5 @@
 import { createInjector } from 'typed-inject';
-import { MutantResult } from '@stryker-mutator/api/core';
+import { MutantResult, PartialStrykerOptions } from '@stryker-mutator/api/core';
 
 import { provideLogger } from './../../di/provide-logger.js';
 import { PrepareExecutor } from './../../process/1-prepare-executor.js';
@@ -11,14 +11,13 @@ export class InstrumentMethod {
    * @param globPatterns The glob patterns to instrument.
    * @returns The mutant results.
    */
-  public static async runInstrumentation(globPatterns?: string[], injectorFactory = createInjector): Promise<MutantResult[]> {
+  public static async runInstrumentation(options: PartialStrykerOptions, injectorFactory = createInjector): Promise<MutantResult[]> {
     const rootInjector = injectorFactory();
 
     const loggerProvider = provideLogger(rootInjector);
 
     const prepareExecutor = loggerProvider.injectClass(PrepareExecutor);
 
-    const options = globPatterns?.length ? { mutate: globPatterns } : {};
     const mutantInstrumenterInjector = await prepareExecutor.execute(options);
 
     const mutantInstrumenter = mutantInstrumenterInjector.injectClass(ServerMutantInstrumenterExecutor);

--- a/packages/core/src/server/methods/mutation-test-method.ts
+++ b/packages/core/src/server/methods/mutation-test-method.ts
@@ -22,11 +22,10 @@ export class MutationTestMethod {
    * @param onMutantTested  A callback that is called when a mutant is tested.
    */
   public async runMutationTestRealtime(
-    globPatterns: string[] | undefined,
+    options: PartialStrykerOptions,
     abortSignal: AbortSignal,
     onMutantTested: (result: Readonly<MutantResult>) => void,
   ): Promise<void> {
-    const options: PartialStrykerOptions = globPatterns?.length ? { mutate: globPatterns } : {};
     options.reporters = ['empty']; // used to stream results
 
     const rootInjector = this.injectorFactory();
@@ -93,7 +92,7 @@ export class MutationTestMethod {
    * @param globPatterns The glob patterns to mutate.
    * @returns The mutant results.
    */
-  public static async runMutationTest(abortSignal: AbortSignal, globPatterns?: string[]): Promise<MutantResult[]> {
-    return await new Stryker({ mutate: globPatterns }).runMutationTest(abortSignal);
+  public static async runMutationTest(abortSignal: AbortSignal, options: PartialStrykerOptions): Promise<MutantResult[]> {
+    return await new Stryker(options).runMutationTest(abortSignal);
   }
 }

--- a/packages/core/src/server/mutation-server-protocol.ts
+++ b/packages/core/src/server/mutation-server-protocol.ts
@@ -1,5 +1,14 @@
 import { MutantResult } from '@stryker-mutator/api/core';
 
+export interface InitializeParams {
+  /**
+   * The URI of the mutation testing framework config file
+   */
+  configUri?: string;
+}
+
+export const InitializeResult = {};
+
 export type ProgressToken = number | string;
 
 export interface ProgressParams<T> {
@@ -79,10 +88,17 @@ export const ErrorCodes = {
    * the cancel.
    */
   RequestCancelled: -32000,
+
+  /**
+   * Error code indicating that a server received a notification or
+   * request before the server has received the `initialize` request.
+   */
+  ServerNotInitialized: -32001,
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ServerMethods = {
+  initialize(params: InitializeParams): Promise<typeof InitializeResult>;
   instrument(params: InstrumentParams): Promise<MutantResult[]>;
   mutate(params: MutateParams): Promise<MutantResult[]>;
 };

--- a/packages/core/test/unit/server/methods/instrument-method.spec.ts
+++ b/packages/core/test/unit/server/methods/instrument-method.spec.ts
@@ -39,20 +39,15 @@ describe(InstrumentMethod.name, () => {
 
   describe('runInstrumentation', () => {
     it('should run the instrumentation if no glob patterns are provided', async () => {
-      const result = await InstrumentMethod.runInstrumentation(undefined, () => injectorStub);
+      const result = await InstrumentMethod.runInstrumentation({}, () => injectorStub);
       expect(result).to.deep.equal([]);
       expect(mutantInstrumenterExecutorMock.execute).calledOnce;
     });
 
     it('should run the instrumentation with the provided glob patterns', async () => {
       const globPatterns = ['glob/pattern'];
-      await InstrumentMethod.runInstrumentation(globPatterns, () => injectorStub);
+      await InstrumentMethod.runInstrumentation({ mutate: globPatterns }, () => injectorStub);
       expect(prepareExecutorMock.execute).calledOnceWith({ mutate: globPatterns });
-    });
-
-    it('should not overwrite mutate property if no glob patterns are provided', async () => {
-      await InstrumentMethod.runInstrumentation([], () => injectorStub);
-      expect(prepareExecutorMock.execute).calledOnceWith({});
     });
   });
 });

--- a/packages/core/test/unit/server/methods/mutation-test-method.spec.ts
+++ b/packages/core/test/unit/server/methods/mutation-test-method.spec.ts
@@ -81,31 +81,31 @@ describe(MutationTestMethod.name, () => {
 
   describe('runMutationTestRealtime', () => {
     it('should execute the preparations', async () => {
-      await sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined);
+      await sut.runMutationTestRealtime({}, abortController.signal, () => undefined);
       expect(prepareExecutorMock.execute).calledOnce;
     });
     it('should execute the mutant instrumenter', async () => {
-      await sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined);
+      await sut.runMutationTestRealtime({}, abortController.signal, () => undefined);
       expect(mutantInstrumenterExecutorMock.execute).calledOnce;
     });
     it('should execute the dry run', async () => {
-      await sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined);
+      await sut.runMutationTestRealtime({}, abortController.signal, () => undefined);
       expect(dryRunExecutorMock.execute).calledOnce;
     });
 
     it('should execute actual mutation testing', async () => {
-      await sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined);
+      await sut.runMutationTestRealtime({}, abortController.signal, () => undefined);
       expect(mutationTestExecutorMock.execute).calledOnce;
     });
 
     it('should reject when empty reporter is not available', async () => {
       (reporterStub.reporters as any) = {};
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejectedWith('Reporter unavailable');
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejectedWith('Reporter unavailable');
     });
 
     it('should execute prepare with the given glob patterns and empty reporter', async () => {
       const globPatterns = ['foo.js', 'bar.js'];
-      await sut.runMutationTestRealtime(globPatterns, abortController.signal, () => undefined);
+      await sut.runMutationTestRealtime({ mutate: globPatterns }, abortController.signal, () => undefined);
 
       expect(prepareExecutorMock.execute).calledOnceWith({ mutate: globPatterns, reporters: ['empty'] });
     });
@@ -113,44 +113,44 @@ describe(MutationTestMethod.name, () => {
     it('should reject when prepare rejects', async () => {
       const expectedError = new Error('expected error for testing');
       prepareExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejectedWith(expectedError);
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejectedWith(expectedError);
     });
 
     it('should not log a stack trace for a config error', async () => {
       const expectedError = new ConfigError('foo should be bar');
       prepareExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(loggerMock.error).calledWithExactly('foo should be bar');
     });
 
     it('should reject when execute the mutant instrumenter rejects', async () => {
       const expectedError = new Error('expected error for testing');
       mutationTestExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejectedWith(expectedError);
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejectedWith(expectedError);
     });
 
     it('should reject when execute the dry run rejects', async () => {
       const expectedError = new Error('expected error for testing');
       dryRunExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejectedWith(expectedError);
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejectedWith(expectedError);
     });
 
     it('should reject when execute actual mutation testing rejects', async () => {
       const expectedError = new Error('expected error for testing');
       mutationTestExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejectedWith(expectedError);
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejectedWith(expectedError);
     });
 
     it('should log the error when prepare rejects unexpectedly', async () => {
       const expectedError = new Error('expected error for testing');
       prepareExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(loggerMock.error).calledWith('Unexpected error occurred while running Stryker', expectedError);
     });
 
     it('should disable `removeDuringDisposal` on the temp dir when dry run rejects', async () => {
       dryRunExecutorMock.execute.rejects(new Error('expected error for testing'));
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(getLoggerStub).calledWith('Stryker');
       expect(loggerMock.debug).calledWith('Not removing the temp dir because an error occurred');
       expect(temporaryDirectoryMock.removeDuringDisposal).false;
@@ -159,14 +159,14 @@ describe(MutationTestMethod.name, () => {
     it('should not disable `removeDuringDisposal` on the temp dir when dry run rejects and cleanTempDir is set to `always`', async () => {
       dryRunExecutorMock.execute.rejects(new Error('expected error for testing'));
       testInjector.options.cleanTempDir = 'always';
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(temporaryDirectoryMock.removeDuringDisposal).not.false;
     });
 
     it('should log the error when dry run rejects unexpectedly', async () => {
       const expectedError = new Error('expected error for testing');
       dryRunExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(getLoggerStub).calledWith('Stryker');
       expect(loggerMock.error).calledWith('Unexpected error occurred while running Stryker', expectedError);
     });
@@ -175,7 +175,7 @@ describe(MutationTestMethod.name, () => {
       const expectedError = new Error('expected error for testing');
       loggerMock.isTraceEnabled.returns(false);
       dryRunExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       [
         'This might be a known problem with a solution documented in our troubleshooting guide.',
         'You can find it at https://stryker-mutator.io/docs/stryker-js/troubleshooting/',
@@ -187,7 +187,7 @@ describe(MutationTestMethod.name, () => {
       const expectedError = new Error('expected error for testing');
       loggerMock.isTraceEnabled.returns(true);
       dryRunExecutorMock.execute.rejects(expectedError);
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       [
         'This might be a known problem with a solution documented in our troubleshooting guide.',
         'You can find it at https://stryker-mutator.io/docs/stryker-js/troubleshooting/',
@@ -195,27 +195,28 @@ describe(MutationTestMethod.name, () => {
     });
 
     it('should dispose the injector', async () => {
-      await sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined), expect(injectorMock.dispose).called;
+      await sut.runMutationTestRealtime({}, abortController.signal, () => undefined), expect(injectorMock.dispose).called;
     });
 
     it('should dispose also on a rejection injector', async () => {
       prepareExecutorMock.execute.rejects(new Error('expected error'));
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(injectorMock.dispose).called;
     });
 
     it('should shut down the logging server', async () => {
-      await sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined), expect(shutdownLoggingStub).called;
+      await sut.runMutationTestRealtime({}, abortController.signal, () => undefined), expect(shutdownLoggingStub).called;
     });
 
     it('should dispose the injector when actual mutation testing rejects', async () => {
       mutationTestExecutorMock.execute.rejects(new Error('Expected error for testing'));
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(injectorMock.dispose).called;
     });
+
     it('should shut down the logging server when actual mutation testing rejects', async () => {
       mutationTestExecutorMock.execute.rejects(new Error('Expected error for testing'));
-      await expect(sut.runMutationTestRealtime(undefined, abortController.signal, () => undefined)).rejected;
+      await expect(sut.runMutationTestRealtime({}, abortController.signal, () => undefined)).rejected;
       expect(shutdownLoggingStub).called;
     });
   });

--- a/packages/core/test/unit/server/mutation-server-protocol-handler.spec.ts
+++ b/packages/core/test/unit/server/mutation-server-protocol-handler.spec.ts
@@ -1,18 +1,32 @@
 import { EventEmitter } from 'events';
 
 import sinon from 'sinon';
-import { JSONRPCServerAndClient, createJSONRPCNotification, createJSONRPCRequest, createJSONRPCSuccessResponse } from 'json-rpc-2.0';
-import { expect } from 'chai';
+import {
+  JSONRPCServerAndClient,
+  createJSONRPCErrorResponse,
+  createJSONRPCNotification,
+  createJSONRPCRequest,
+  createJSONRPCSuccessResponse,
+} from 'json-rpc-2.0';
+import { config, expect } from 'chai';
 import { factory } from '@stryker-mutator/test-helpers';
-import { MutantResult } from '@stryker-mutator/api/core';
+import { MutantResult, PartialStrykerOptions } from '@stryker-mutator/api/core';
 
-import { InstrumentParams, MutateParams, MutatePartialResult, MutationServerProtocolHandler, ProgressParams } from '../../../src/server/index.js';
+import {
+  ErrorCodes,
+  InstrumentParams,
+  MutateParams,
+  MutatePartialResult,
+  MutationServerProtocolHandler,
+  ProgressParams,
+} from '../../../src/server/index.js';
 import { Transporter, TransporterEvents } from '../../../src/server/transport/index.js';
 import { MutationTestMethod, InstrumentMethod } from '../../../src/server/methods/index.js';
 
 describe(MutationServerProtocolHandler.name, () => {
   let transporterMock: TransporterMock;
   let clock: sinon.SinonFakeTimers;
+  let sendSpy: sinon.SinonSpy;
 
   before(() => {
     clock = sinon.useFakeTimers();
@@ -21,6 +35,7 @@ describe(MutationServerProtocolHandler.name, () => {
   beforeEach(() => {
     transporterMock = new TransporterMock();
     new MutationServerProtocolHandler(transporterMock);
+    sendSpy = sinon.spy(transporterMock, 'send');
   });
 
   after(() => {
@@ -29,7 +44,6 @@ describe(MutationServerProtocolHandler.name, () => {
 
   it('should run mutation test on request via transporter', async () => {
     // Arrange
-    const sendSpy = sinon.spy(transporterMock, 'send');
     const mutationTestResult: MutantResult[] = [];
     sinon.replace(MutationTestMethod, 'runMutationTest', sinon.fake.resolves(mutationTestResult));
 
@@ -40,6 +54,8 @@ describe(MutationServerProtocolHandler.name, () => {
     const jsonRpcRequest = createJSONRPCRequest(1, 'mutate', mutateParams);
     const runMutationRequest = JSON.stringify(jsonRpcRequest);
 
+    transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', {})));
+
     // Act
     transporterMock.emit('message', runMutationRequest);
 
@@ -48,12 +64,12 @@ describe(MutationServerProtocolHandler.name, () => {
 
     // Assert
     const successResponse = createJSONRPCSuccessResponse(1, mutationTestResult);
-    expect(sendSpy).calledOnceWith(JSON.stringify(successResponse));
+    expect(sendSpy).calledTwice;
+    expect(sendSpy).calledWith(JSON.stringify(successResponse));
   });
 
   it('should run instrumentation on request via transporter', async () => {
     // Arrange
-    const sendSpy = sinon.spy(transporterMock, 'send');
     const instrumentResult: MutantResult[] = [];
 
     sinon.replace(InstrumentMethod, 'runInstrumentation', sinon.fake.resolves(instrumentResult));
@@ -64,6 +80,8 @@ describe(MutationServerProtocolHandler.name, () => {
     const jsonRpcRequest = createJSONRPCRequest(1, 'instrument', instrumentParams);
     const runInstrumentationRequest = JSON.stringify(jsonRpcRequest);
 
+    transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', {})));
+
     // Act
     transporterMock.emit('message', runInstrumentationRequest);
 
@@ -72,17 +90,17 @@ describe(MutationServerProtocolHandler.name, () => {
 
     // Assert
     const successResponse = createJSONRPCSuccessResponse(1, instrumentResult);
-    expect(sendSpy).calledOnceWith(JSON.stringify(successResponse));
+    expect(sendSpy).calledTwice;
+    expect(sendSpy).calledWith(JSON.stringify(successResponse));
   });
 
   it('should report partial results when partialResultToken is provided in mutation test request', async () => {
     // Arrange
-    const sendSpy = sinon.spy(transporterMock, 'send');
     const mutationTestResult: MutantResult = factory.mutantResult();
     sinon.replace(MutationTestMethod.prototype, 'runMutationTestRealtime', sinon.fake.yields(mutationTestResult));
 
     const partialResultToken = 'token';
-    const requestId = 1;
+    const requestId = 2;
 
     // Create a JSON-RPC request
     const mutateParams: MutateParams = {
@@ -91,6 +109,8 @@ describe(MutationServerProtocolHandler.name, () => {
     };
     const jsonRpcRequest = createJSONRPCRequest(requestId, 'mutate', mutateParams);
     const runMutationRequest = JSON.stringify(jsonRpcRequest);
+
+    transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', {})));
 
     // Act
     transporterMock.emit('message', runMutationRequest);
@@ -105,7 +125,7 @@ describe(MutationServerProtocolHandler.name, () => {
     const progressNotification = createJSONRPCNotification('progress', progressNotificationParams);
 
     // Assert
-    expect(sendSpy).calledTwice;
+    expect(sendSpy).calledThrice;
     expect(sendSpy).calledWith(JSON.stringify(progressNotification));
     expect(sendSpy).calledWith(JSON.stringify(createJSONRPCSuccessResponse(requestId, [])));
   });
@@ -130,6 +150,103 @@ describe(MutationServerProtocolHandler.name, () => {
 
     // Assert
     expect(consoleErrorSpy).calledOnceWith('Error occurred in transporter:', sinon.match.instanceOf(Error));
+  });
+
+  it('should error if server is not initialized', async () => {
+    // Arrange
+    const randomRequest = JSON.stringify(createJSONRPCRequest(1, 'foo', {}));
+    const errorResponse = createJSONRPCErrorResponse(
+      1,
+      ErrorCodes.ServerNotInitialized,
+      'Server is not initialized, you must request initialization first.',
+    );
+
+    // Act
+    transporterMock.emit('message', randomRequest);
+    await clock.tickAsync(1);
+
+    // Assert
+    expect(sendSpy).calledOnceWith(JSON.stringify(errorResponse));
+  });
+
+  it('should error if server is initialized multiple times', async () => {
+    // Arrange
+    const errorResponse = createJSONRPCErrorResponse(
+      2,
+      ErrorCodes.InvalidRequest,
+      'Server is already initialized, you can only request initialization once.',
+    );
+
+    // Act
+    transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', {})));
+    await clock.tickAsync(1);
+    transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(2, 'initialize', {})));
+    await clock.tickAsync(1);
+
+    // Assert
+    expect(sendSpy).calledTwice;
+    expect(sendSpy).calledWith(JSON.stringify(errorResponse));
+  });
+
+  it('should use the stryker options from the initialize request in instrument run', async () => {
+    // Arrange
+    transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', { configUri: 'foo' })));
+
+    // Create a JSON-RPC request
+    const instrumentParams: InstrumentParams = {
+      globPatterns: ['bar'],
+    };
+    const jsonRpcRequest = createJSONRPCRequest(1, 'instrument', instrumentParams);
+    const runMutationRequest = JSON.stringify(jsonRpcRequest);
+
+    const fake = sinon.fake.resolves([]);
+
+    sinon.replace(InstrumentMethod, 'runInstrumentation', fake);
+
+    const expectedOptions: PartialStrykerOptions = {
+      configFile: 'foo',
+      mutate: ['bar'],
+    };
+
+    // Act
+    transporterMock.emit('message', runMutationRequest);
+
+    await clock.tickAsync(1);
+
+    // Assert
+    expect(sendSpy).calledTwice;
+    expect(fake).calledWithExactly(expectedOptions);
+  });
+
+  it('should use the stryker options from the initialize request in mutation run', async () => {
+    // Arrange
+    transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', { configUri: 'foo' })));
+
+    // Create a JSON-RPC request
+    const mutateParams: MutateParams = {
+      globPatterns: ['bar'],
+    };
+
+    const jsonRpcRequest = createJSONRPCRequest(1, 'mutate', mutateParams);
+    const runMutationRequest = JSON.stringify(jsonRpcRequest);
+
+    const fake = sinon.fake.resolves([]);
+
+    sinon.replace(MutationTestMethod, 'runMutationTest', fake);
+
+    const expectedOptions: PartialStrykerOptions = {
+      configFile: 'foo',
+      mutate: ['bar'],
+    };
+
+    // Act
+    transporterMock.emit('message', runMutationRequest);
+
+    await clock.tickAsync(1);
+
+    // Assert
+    expect(sendSpy).calledTwice;
+    expect(fake).calledWithExactly(sinon.match.any, expectedOptions);
   });
 });
 


### PR DESCRIPTION
This feature introduces an initialization request to the mutation server, allowing clients (such as the VS Code extension) to set the location of the Stryker config file. This specified location will be used in all subsequent requests.

Documentation of the protocol changes can be found in this PR: https://github.com/jaspervdveen/vscode-stryker/pull/12 

PBI 6048