### PR TITLE
Fix tests, refactor mutate request, change init request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26539,9 +26539,9 @@
       }
     },
     "packages/core/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26539,9 +26539,9 @@
       }
     },
     "packages/core/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/packages/core/src/server/methods/mutation-test-method.ts
+++ b/packages/core/src/server/methods/mutation-test-method.ts
@@ -18,7 +18,7 @@ export class MutationTestMethod {
 
   /**
    * Run a mutation test and get partial results via a callback.
-   * @param globPatterns  The glob patterns to mutate.
+   * @param globPatterns  The glob patterns to mutation test.
    * @param onMutantTested  A callback that is called when a mutant is tested.
    */
   public async runMutationTestRealtime(
@@ -89,7 +89,7 @@ export class MutationTestMethod {
 
   /**
    * Run a mutation test.
-   * @param globPatterns The glob patterns to mutate.
+   * @param globPatterns The glob patterns to mutation test.
    * @returns The mutant results.
    */
   public static async runMutationTest(abortSignal: AbortSignal, options: PartialStrykerOptions): Promise<MutantResult[]> {

--- a/packages/core/src/server/mutation-server-protocol-handler.ts
+++ b/packages/core/src/server/mutation-server-protocol-handler.ts
@@ -21,8 +21,8 @@ import {
   CancelNotification,
   ClientMethods,
   InstrumentParams,
-  MutateParams,
-  MutatePartialResult,
+  MutationTestParams,
+  MutationTestPartialResult,
   ProgressParams,
   ErrorCodes,
   ServerMethods,
@@ -88,7 +88,7 @@ export class MutationServerProtocolHandler {
   }
 
   private setupServerMethods(): void {
-    this.serverAndClient.addMethodAdvanced('mutate', this.runMutationTestServerMethod.bind(this));
+    this.serverAndClient.addMethodAdvanced('mutationTest', this.runMutationTestServerMethod.bind(this));
     this.serverAndClient.addMethod('instrument', this.runInstrumentation.bind(this));
     this.serverAndClient.addMethod('initialize', this.initialize.bind(this));
   }
@@ -131,7 +131,7 @@ export class MutationServerProtocolHandler {
   }
 
   private async runMutationTestServerMethod(jsonRPCRequest: JSONRPCRequest): Promise<JSONRPCResponse> {
-    const params = jsonRPCRequest.params as MutateParams;
+    const params = jsonRPCRequest.params as MutationTestParams;
 
     if (!jsonRPCRequest.id) {
       throw new Error('Request id is required.');
@@ -155,7 +155,7 @@ export class MutationServerProtocolHandler {
     try {
       if (partialResultToken) {
         await new MutationTestMethod().runMutationTestRealtime(options, signal, (result) => {
-          const progressParams: ProgressParams<MutatePartialResult> = { token: partialResultToken, value: { mutants: [result] } };
+          const progressParams: ProgressParams<MutationTestPartialResult> = { token: partialResultToken, value: { mutants: [result] } };
           this.serverAndClient.notify('progress', progressParams);
         });
       } else {

--- a/packages/core/src/server/mutation-server-protocol.ts
+++ b/packages/core/src/server/mutation-server-protocol.ts
@@ -2,12 +2,67 @@ import { MutantResult } from '@stryker-mutator/api/core';
 
 export interface InitializeParams {
   /**
+   * Information about the client.
+   */
+  clientInfo: {
+    /**
+     * The client's version as defined by the client.
+     */
+    version: string;
+  };
+  /**
    * The URI of the mutation testing framework config file
    */
   configUri?: string;
 }
 
-export const InitializeResult = {};
+export interface PartialResultOptions {
+  /**
+   * The server supports returning partial results.
+   */
+  partialResults?: boolean;
+}
+
+/**
+ * The options for instrumentation provider.
+ */
+type InstrumentationOptions = PartialResultOptions;
+
+/**
+ * The options for mutation testing provider.
+ */
+type MutationTestOptions = PartialResultOptions;
+
+/**
+ * The capabilities provided by the server.
+ */
+export interface ServerCapabilities {
+  /**
+   * The server provides support for instrument runs.
+   */
+  instrumentationProvider?: InstrumentationOptions;
+  /**
+   * The server provides support for mutation test runs.
+   */
+  mutationTestProvider?: MutationTestOptions;
+}
+
+export interface InitializeResult {
+  /**
+   * The capabilities the mutation server provides.
+   */
+  capabilities?: ServerCapabilities;
+
+  /**
+   * The server's information.
+   */
+  serverInfo: {
+    /**
+     * The server's version as defined by the server.
+     */
+    version: string;
+  };
+}
 
 export type ProgressToken = number | string;
 
@@ -98,7 +153,7 @@ export const ErrorCodes = {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ServerMethods = {
-  initialize(params: InitializeParams): Promise<typeof InitializeResult>;
+  initialize(params: InitializeParams): Promise<InitializeResult>;
   instrument(params: InstrumentParams): Promise<MutantResult[]>;
   mutate(params: MutateParams): Promise<MutantResult[]>;
 };

--- a/packages/core/src/server/mutation-server-protocol.ts
+++ b/packages/core/src/server/mutation-server-protocol.ts
@@ -92,9 +92,9 @@ export interface InstrumentParams {
   globPatterns?: string[];
 }
 
-export interface MutateParams extends PartialResultParams {
+export interface MutationTestParams extends PartialResultParams {
   /**
-   * The glob patterns to mutate.
+   * The glob patterns to mutation test.
    */
   globPatterns?: string[];
 }
@@ -106,7 +106,7 @@ export interface CancelParams {
   id: number | string;
 }
 
-export interface MutatePartialResult {
+export interface MutationTestPartialResult {
   /**
    * The mutant results.
    */
@@ -155,7 +155,7 @@ export const ErrorCodes = {
 export type ServerMethods = {
   initialize(params: InitializeParams): Promise<InitializeResult>;
   instrument(params: InstrumentParams): Promise<MutantResult[]>;
-  mutate(params: MutateParams): Promise<MutantResult[]>;
+  mutationTest(params: MutationTestParams): Promise<MutantResult[]>;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions

--- a/packages/core/src/server/transport/web-socket-transporter.ts
+++ b/packages/core/src/server/transport/web-socket-transporter.ts
@@ -54,4 +54,8 @@ export class WebSocketTransporter extends EventEmitter<TransporterEvents> implem
       }
     });
   }
+
+  public close(): void {
+    this.webSocketServer.close();
+  }
 }

--- a/packages/core/test/unit/server/mutation-server-protocol-handler.spec.ts
+++ b/packages/core/test/unit/server/mutation-server-protocol-handler.spec.ts
@@ -51,10 +51,10 @@ describe(MutationServerProtocolHandler.name, () => {
     sinon.replace(MutationTestMethod, 'runMutationTest', sinon.fake.resolves(mutationTestResult));
 
     // Create a JSON-RPC request
-    const mutateParams: MutationTestParams = {
+    const mutationTestParams: MutationTestParams = {
       globPatterns: ['foo'],
     };
-    const jsonRpcRequest = createJSONRPCRequest(1, 'mutate', mutateParams);
+    const jsonRpcRequest = createJSONRPCRequest(1, 'mutationTest', mutationTestParams);
     const runMutationRequest = JSON.stringify(jsonRpcRequest);
 
     transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', initializeParams)));
@@ -106,11 +106,11 @@ describe(MutationServerProtocolHandler.name, () => {
     const requestId = 2;
 
     // Create a JSON-RPC request
-    const mutateParams: MutationTestParams = {
+    const mutationTestParams: MutationTestParams = {
       globPatterns: ['foo', 'bar', 'baz'],
       partialResultToken,
     };
-    const jsonRpcRequest = createJSONRPCRequest(requestId, 'mutate', mutateParams);
+    const jsonRpcRequest = createJSONRPCRequest(requestId, 'mutationTest', mutationTestParams);
     const runMutationRequest = JSON.stringify(jsonRpcRequest);
 
     transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', initializeParams)));
@@ -226,11 +226,11 @@ describe(MutationServerProtocolHandler.name, () => {
     transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', { ...initializeParams, configUri: 'foo' })));
 
     // Create a JSON-RPC request
-    const mutateParams: MutationTestParams = {
+    const mutationTestParams: MutationTestParams = {
       globPatterns: ['bar'],
     };
 
-    const jsonRpcRequest = createJSONRPCRequest(1, 'mutate', mutateParams);
+    const jsonRpcRequest = createJSONRPCRequest(1, 'mutationTest', mutationTestParams);
     const runMutationRequest = JSON.stringify(jsonRpcRequest);
 
     const fake = sinon.fake.resolves([]);

--- a/packages/core/test/unit/server/mutation-server-protocol-handler.spec.ts
+++ b/packages/core/test/unit/server/mutation-server-protocol-handler.spec.ts
@@ -16,8 +16,8 @@ import {
   ErrorCodes,
   InitializeParams,
   InstrumentParams,
-  MutateParams,
-  MutatePartialResult,
+  MutationTestParams,
+  MutationTestPartialResult,
   MutationServerProtocolHandler,
   ProgressParams,
 } from '../../../src/server/index.js';
@@ -51,7 +51,7 @@ describe(MutationServerProtocolHandler.name, () => {
     sinon.replace(MutationTestMethod, 'runMutationTest', sinon.fake.resolves(mutationTestResult));
 
     // Create a JSON-RPC request
-    const mutateParams: MutateParams = {
+    const mutateParams: MutationTestParams = {
       globPatterns: ['foo'],
     };
     const jsonRpcRequest = createJSONRPCRequest(1, 'mutate', mutateParams);
@@ -106,7 +106,7 @@ describe(MutationServerProtocolHandler.name, () => {
     const requestId = 2;
 
     // Create a JSON-RPC request
-    const mutateParams: MutateParams = {
+    const mutateParams: MutationTestParams = {
       globPatterns: ['foo', 'bar', 'baz'],
       partialResultToken,
     };
@@ -121,7 +121,7 @@ describe(MutationServerProtocolHandler.name, () => {
     // Wait for event loop to finish before asserting
     await clock.tickAsync(1);
 
-    const progressNotificationParams: ProgressParams<MutatePartialResult> = {
+    const progressNotificationParams: ProgressParams<MutationTestPartialResult> = {
       token: partialResultToken,
       value: { mutants: [mutationTestResult] },
     };
@@ -226,7 +226,7 @@ describe(MutationServerProtocolHandler.name, () => {
     transporterMock.emit('message', JSON.stringify(createJSONRPCRequest(1, 'initialize', { ...initializeParams, configUri: 'foo' })));
 
     // Create a JSON-RPC request
-    const mutateParams: MutateParams = {
+    const mutateParams: MutationTestParams = {
       globPatterns: ['bar'],
     };
 

--- a/packages/core/test/unit/server/transport/web-socket-transporter.spec.ts
+++ b/packages/core/test/unit/server/transport/web-socket-transporter.spec.ts
@@ -22,12 +22,13 @@ describe(WebSocketTransporter.name, () => {
     logSpy.restore();
   });
 
-  after(() => {
+  afterEach(() => {
     clock.restore();
+    transporter.close();
   });
 
   it('should log the port when the server is listening', async () => {
-    new WebSocketTransporter(0);
+    const webSocketTransporter = new WebSocketTransporter(0);
 
     const logSpy = sinon.spy(console, 'log');
 
@@ -36,6 +37,7 @@ describe(WebSocketTransporter.name, () => {
 
     expect(logSpy).calledOnce;
     expect(logSpy.calledWith('Server is listening on port:', sinon.match.number)).to.be.true;
+    webSocketTransporter.close();
   });
 
   it('should emit connected event when a client connects', async () => {
@@ -108,7 +110,7 @@ describe(WebSocketTransporter.name, () => {
     const logSpy = sinon.spy(console, 'log');
 
     // Arrange
-    new WebSocketTransporter();
+    const webSocketTransporter = new WebSocketTransporter();
 
     // Act
     await clock.tickAsync(1);
@@ -117,6 +119,7 @@ describe(WebSocketTransporter.name, () => {
     expect(logSpy).calledOnce;
     expect(logSpy.firstCall.args[1] !== 0).to.be.true;
     expect(logSpy.calledWith('Server is listening on port:', sinon.match.number)).to.be.true;
+    webSocketTransporter.close();
   });
 
   async function getWebSocketConnection(): Promise<WebSocket> {


### PR DESCRIPTION
Features:
- changes to the initialization handshake to adhere to a Mutation Server Protocol version (PBI 7340)

Fixes:
- An issue which caused the CI pipeline to keep on running, even when all tests passed.

Refactors:
- Renamed 'mutate' request to 'mutationTest'

Corresponding vscode-stryker PR: https://github.com/jaspervdveen/vscode-stryker/pull/13